### PR TITLE
Maui - Fixed SfListView visibility issue after item tap and improve UI padding.

### DIFF
--- a/WeatherAnalysis/Views/Desktop/HourlyPage.xaml
+++ b/WeatherAnalysis/Views/Desktop/HourlyPage.xaml
@@ -204,7 +204,7 @@
 
             <!--Date Tile-->
 
-            <Grid Padding="0,0,15,0" RowDefinitions="*"  Grid.Row="1" >
+            <Grid Padding="0,10,15,10"  RowDefinitions="*"  Grid.Row="1" >
 
                 <ScrollView x:Name="scrollView" Grid.Row="0" Orientation="Horizontal" HorizontalScrollBarVisibility="Never">
                     <listview:SfListView x:Name="forcastList"
@@ -212,10 +212,10 @@
                                       Grid.Row="0"
                                       ItemsSource="{Binding HourlyForecasts}"
                                       SelectedItem="{Binding SelectedTile}" 
-                                      HeightRequest="120"
+                                      MaximumHeightRequest="120"
                                       Orientation="Horizontal"
-                                         IsScrollingEnabled="False"
-                                     HorizontalOptions="Center"
+                                      IsScrollingEnabled="False"
+                                      HorizontalOptions="StartAndExpand"
                                       ItemSpacing="0,0,12,0"
                                       ScrollBarVisibility="Never"
                                       SelectionChangedCommand="{Binding SelectionChangedCommand}">


### PR DESCRIPTION
### Description

- Fixed a bug where SfListView was hidden after tapping an item.
- Root cause: tapping an item caused the list view to scroll and get hidden behind other UI elements.
- The issue was reproducible—list view reappeared on vertical scroll but hid again on tapping another item.
- Applied MaximumHeightRequest to SfListView to maintain consistent visibility.
- Adjusted padding values to enhance UI neatness and alignment.

### Demo: 

https://github.com/user-attachments/assets/4334ced1-611c-43dd-a772-0f2b9f810eea

